### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,8 +5,8 @@ BACK_ButtonRoutine	KEYWORD2
 doEncoder1	KEYWORD2
 doEncoder2	KEYWORD2
 createRecord	KEYWORD2
-SetGlobalParameter KEYWORD2
-GetViewID KEYWORD2
+SetGlobalParameter	KEYWORD2
+GetViewID	KEYWORD2
 
-BP KEYWORD2
-db_screen KEYWORD2
+BP	KEYWORD2
+db_screen	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords